### PR TITLE
Fix tiny garden particles not being randomized

### DIFF
--- a/src/client/java/co/secretonline/tinyflowers/TinyFlowersClient.java
+++ b/src/client/java/co/secretonline/tinyflowers/TinyFlowersClient.java
@@ -6,9 +6,14 @@ import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.item.ItemRenderState;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.biome.GrassColors;
 
 public class TinyFlowersClient implements ClientModInitializer {
+	public static final Random RANDOM = Random.create();
+	public static final ItemRenderState ITEM_RENDER_STATE = new ItemRenderState();
+
 	@Override
 	public void onInitializeClient() {
 		BlockRenderLayerMap.INSTANCE.putBlock(ModBlocks.TINY_GARDEN, RenderLayer.getCutout());

--- a/src/client/java/co/secretonline/tinyflowers/mixin/BlockModelsMixin.java
+++ b/src/client/java/co/secretonline/tinyflowers/mixin/BlockModelsMixin.java
@@ -1,0 +1,37 @@
+package co.secretonline.tinyflowers.mixin;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import co.secretonline.tinyflowers.TinyFlowersClient;
+import co.secretonline.tinyflowers.blocks.FlowerVariant;
+import co.secretonline.tinyflowers.blocks.GardenBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.block.BlockModels;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ModelTransformationMode;
+import net.minecraft.util.Util;
+
+@Mixin(BlockModels.class)
+public class BlockModelsMixin {
+	@Inject(method = "getModelParticleSprite", at = @At("HEAD"), cancellable = true)
+	private void randomizeGardenModelParticleSprite(BlockState state, CallbackInfoReturnable<Sprite> info) {
+		if (state.getBlock() instanceof GardenBlock) {
+			// Select a random flower variant to render as the particle
+			List<FlowerVariant> flowers = GardenBlock.getFlowers(state);
+			FlowerVariant variant = Util.getRandom(flowers, TinyFlowersClient.RANDOM);
+
+			MinecraftClient client = MinecraftClient.getInstance();
+			ItemStack stack = new ItemStack(variant.asItem());
+
+			client.getItemModelManager().update(TinyFlowersClient.ITEM_RENDER_STATE, stack, ModelTransformationMode.GROUND, false, client.world, null, 0);
+			info.setReturnValue(TinyFlowersClient.ITEM_RENDER_STATE.getParticleSprite(TinyFlowersClient.RANDOM));
+		}
+	}
+}

--- a/src/main/java/co/secretonline/tinyflowers/blocks/GardenBlock.java
+++ b/src/main/java/co/secretonline/tinyflowers/blocks/GardenBlock.java
@@ -1,5 +1,6 @@
 package co.secretonline.tinyflowers.blocks;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -254,6 +255,20 @@ public class GardenBlock extends PlantBlock implements Fertilizable {
 		}
 
 		return numFlowers;
+	}
+
+	public static List<FlowerVariant> getFlowers(BlockState state) {
+		List<FlowerVariant> flowers = new ArrayList<>(GardenBlock.FLOWER_VARIANT_PROPERTIES.length);
+
+		for (EnumProperty<FlowerVariant> property : GardenBlock.FLOWER_VARIANT_PROPERTIES) {
+			FlowerVariant variant = state.get(property);
+
+			if (!variant.isEmpty()) {
+				flowers.add(variant);
+			}
+		}
+
+		return flowers;
 	}
 
 	/**

--- a/src/main/resources/tiny-flowers.mixins.json
+++ b/src/main/resources/tiny-flowers.mixins.json
@@ -5,6 +5,9 @@
 	"mixins": [
 		"FlowerbedBlockMixin"
 	],
+	"client": [
+		"BlockModelsMixin"
+	],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
Multipart block models always use their first rule's model for their particle sprite, regardless of whether that rule is selected. This pull request introduces a mixin to replace the model-driven behavior for tiny gardens in favor of a solution that selects a random flower variant to draw particles from. A key benefit of this solution is that the particle sprite is sampled independently, so flower variants are represented proportionally in each burst of particles.

Fixes #3