### PR TITLE
[Auto] Update to Minecraft 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ maven_group=co.secretonline.tinyflowers
 archives_base_name=tiny-flowers
 
 # Dependencies
-fabric_version=0.115.1+1.21.4
+fabric_version=0.119.2+1.21.4


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.4` (Compatible: `~1.21.4`)|
|Java|`21`|
|Yarn Mappings|`1.21.4+build.8`|
|Fabric API|`0.119.2+1.21.4`|
|Mod Menu|`13.0.3`|
|Fabric Loader|`0.16.10`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

