### PR TITLE
[Auto] Update to Minecraft 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.10
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.6
+loader_version=0.16.14
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,4 +17,4 @@ maven_group=co.secretonline.tinyflowers
 archives_base_name=tiny-flowers
 
 # Dependencies
-fabric_version=0.119.6+1.21.5
+fabric_version=0.129.0+1.21.7

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -57,7 +57,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.16.10",
+    "fabricloader": ">=0.16.14",
     "minecraft": "~1.21.5"
   },
   "custom": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.7` (Compatible: `~1.21.5`)|
|Java|`21`|
|Yarn Mappings|`1.21.7+build.6`|
|Fabric API|`0.129.0+1.21.7`|
|Mod Menu|`15.0.0-beta.3`|
|Fabric Loader|`0.16.14`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

