### PR TITLE
[Auto] Update to Minecraft 1.21.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The versioning scheme is listed in the README.
 
 ## Unreleased - DATE
 
+## v1.4.0 - 2025-10-05
+
+### Updated
+
+- Updated to 1.21.9
+
 ## v1.3.0 - 2025-08-07
 
 Big thank you to [eSonOfAnder](https://github.com/eSonOfAnder) for doing the 1.21.6+ update for me.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.16.14
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
+loader_version=0.17.2
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,4 +17,4 @@ maven_group=co.secretonline.tinyflowers
 archives_base_name=tiny-flowers
 
 # Dependencies
-fabric_version=0.131.0+1.21.8
+fabric_version=0.134.0+1.21.9

--- a/src/client/java/co/secretonline/tinyflowers/TinyFlowersClient.java
+++ b/src/client/java/co/secretonline/tinyflowers/TinyFlowersClient.java
@@ -6,7 +6,6 @@ import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.client.render.BlockRenderLayer;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.item.ItemRenderState;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.biome.DryFoliageColors;

--- a/src/client/java/co/secretonline/tinyflowers/datagen/BlockTagProvider.java
+++ b/src/client/java/co/secretonline/tinyflowers/datagen/BlockTagProvider.java
@@ -5,8 +5,6 @@ import java.util.concurrent.CompletableFuture;
 import co.secretonline.tinyflowers.blocks.ModBlocks;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
-import net.minecraft.block.Block;
-import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.tag.BlockTags;
 

--- a/src/client/java/co/secretonline/tinyflowers/datagen/ItemTagProvider.java
+++ b/src/client/java/co/secretonline/tinyflowers/datagen/ItemTagProvider.java
@@ -10,7 +10,6 @@ import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags;
 import net.minecraft.data.tag.ProvidedTagBuilder;
 import net.minecraft.item.Item;
-import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.tag.ItemTags;
 
@@ -21,7 +20,7 @@ public class ItemTagProvider extends FabricTagProvider.FabricValueLookupTagProvi
 
 	@Override
 	protected void configure(RegistryWrapper.WrapperLookup wrapperLookup) {
-		ProvidedTagBuilder builder = valueLookupBuilder(ModItemTags.TINY_FLOWERS);
+		ProvidedTagBuilder<Item, Item> builder = valueLookupBuilder(ModItemTags.TINY_FLOWERS);
 
 		// Add all items/blocks that correspond to tiny flower variants to tag
 		for (FlowerVariant variant : FlowerVariant.values()) {

--- a/src/client/java/co/secretonline/tinyflowers/mixin/BlockDustParticleMixin.java
+++ b/src/client/java/co/secretonline/tinyflowers/mixin/BlockDustParticleMixin.java
@@ -4,15 +4,17 @@ import java.util.List;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArgs;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import co.secretonline.tinyflowers.TinyFlowersClient;
 import co.secretonline.tinyflowers.blocks.FlowerVariant;
 import co.secretonline.tinyflowers.blocks.GardenBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.particle.BillboardParticle;
 import net.minecraft.client.particle.BlockDustParticle;
+import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.ItemDisplayContext;
 import net.minecraft.item.ItemStack;
@@ -20,31 +22,43 @@ import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 
 @Mixin(BlockDustParticle.class)
-abstract class BlockDustParticleMixin {
-	@ModifyArgs(method = "<init>(Lnet/minecraft/client/world/ClientWorld;DDDDDDLnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V", at = @At(value = "INVOKE", target = "net/minecraft/client/particle.BlockDustParticle.setSprite(Lnet/minecraft/client/texture/Sprite;)V"))
-	private void modifySetSpriteArgument(
-			Args args, ClientWorld world,
-			double x, double y, double z,
+abstract class BlockDustParticleMixin extends BillboardParticle {
+	protected BlockDustParticleMixin(ClientWorld world, double x, double y, double z, Sprite sprite) {
+		super(world, x, y, z, sprite);
+		throw new Error("Should not directly instatiiate mixin");
+	}
+
+	@Inject(method = "<init>(Lnet/minecraft/client/world/ClientWorld;DDDDDDLnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V", at = @At("RETURN"))
+	private void onConstructorReturn(ClientWorld world, double x, double y, double z,
 			double velocityX, double velocityY, double velocityZ,
-			BlockState state, BlockPos blockPos) {
-		if (state.getBlock() instanceof GardenBlock) {
-			// Select a random flower variant to render as the particle
-			List<FlowerVariant> flowers = GardenBlock.getFlowers(state);
-
-			if (flowers.isEmpty()) {
-				return;
-			}
-
-			FlowerVariant variant = Util.getRandom(flowers, TinyFlowersClient.RANDOM);
-
-			MinecraftClient client = MinecraftClient.getInstance();
-			ItemStack stack = new ItemStack(variant.asItem());
-
-			TinyFlowersClient.ITEM_RENDER_STATE.clear();
-			client.getItemModelManager()
-					.update(TinyFlowersClient.ITEM_RENDER_STATE, stack, ItemDisplayContext.GROUND, client.world, null, 0);
-
-			args.set(0, TinyFlowersClient.ITEM_RENDER_STATE.getParticleSprite(TinyFlowersClient.RANDOM));
+			BlockState state, BlockPos blockPos, CallbackInfo ci) {
+		Sprite override = getOverrideSpriteForBlockState(state);
+		if (override != null) {
+			this.setSprite(override);
 		}
+	}
+
+	private static Sprite getOverrideSpriteForBlockState(BlockState state) {
+		if (!(state.getBlock() instanceof GardenBlock)) {
+			return null;
+		}
+
+		// Select a random flower variant to render as the particle
+		List<FlowerVariant> flowers = GardenBlock.getFlowers(state);
+
+		if (flowers.isEmpty()) {
+			return null;
+		}
+
+		FlowerVariant variant = Util.getRandom(flowers, TinyFlowersClient.RANDOM);
+
+		MinecraftClient client = MinecraftClient.getInstance();
+		ItemStack stack = new ItemStack(variant.asItem());
+
+		TinyFlowersClient.ITEM_RENDER_STATE.clear();
+		client.getItemModelManager()
+				.update(TinyFlowersClient.ITEM_RENDER_STATE, stack, ItemDisplayContext.GROUND, client.world, null, 0);
+
+		return TinyFlowersClient.ITEM_RENDER_STATE.getParticleSprite(TinyFlowersClient.RANDOM);
 	}
 }

--- a/src/main/java/co/secretonline/tinyflowers/items/FloristsShearsItem.java
+++ b/src/main/java/co/secretonline/tinyflowers/items/FloristsShearsItem.java
@@ -9,7 +9,6 @@ import co.secretonline.tinyflowers.blocks.ModBlocks;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Segmented;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
@@ -87,7 +86,7 @@ public class FloristsShearsItem extends ShearsItem {
 			// TODO: Figure out if there's a scenario where the player is null
 			if (ctx.getPlayer() != null) {
 				PlayerEntity player = ctx.getPlayer();
-				ctx.getStack().damage(1, player, LivingEntity.getSlotForHand(ctx.getHand()));
+				ctx.getStack().damage(1, player, ctx.getHand());
 
 				world.playSound(player, pos, SoundEvents.BLOCK_GROWING_PLANT_CROP, SoundCategory.BLOCKS, 1.0F, 1.0F);
 			}
@@ -116,7 +115,7 @@ public class FloristsShearsItem extends ShearsItem {
 
 			if (ctx.getPlayer() != null) {
 				PlayerEntity player = ctx.getPlayer();
-				ctx.getStack().damage(1, player, LivingEntity.getSlotForHand(ctx.getHand()));
+				ctx.getStack().damage(1, player, ctx.getHand());
 
 				world.playSound(player, pos, SoundEvents.BLOCK_GROWING_PLANT_CROP, SoundCategory.BLOCKS, 1.0F, 1.0F);
 			}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,15 +41,9 @@
   "icon": "assets/tiny-flowers/icon.png",
   "environment": "*",
   "entrypoints": {
-    "main": [
-      "co.secretonline.tinyflowers.TinyFlowers"
-    ],
-    "client": [
-      "co.secretonline.tinyflowers.TinyFlowersClient"
-    ],
-    "fabric-datagen": [
-      "co.secretonline.tinyflowers.datagen.DataGenerator"
-    ]
+    "main": ["co.secretonline.tinyflowers.TinyFlowers"],
+    "client": ["co.secretonline.tinyflowers.TinyFlowersClient"],
+    "fabric-datagen": ["co.secretonline.tinyflowers.datagen.DataGenerator"]
   },
   "mixins": [
     "tiny-flowers.mixins.json",
@@ -64,7 +58,7 @@
   },
   "recommends": {
     "fabricloader": ">=0.17.2",
-    "minecraft": "~1.21.6"
+    "minecraft": "~1.21.9"
   },
   "custom": {
     "mc-publish": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -63,7 +63,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.16.10",
+    "fabricloader": ">=0.17.2",
     "minecraft": "~1.21.6"
   },
   "custom": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.9` (Compatible: `~1.21.6`)|
|Java|`21`|
|Yarn Mappings|`1.21.9+build.1`|
|Fabric API|`0.134.0+1.21.9`|
|Mod Menu|`16.0.0-rc.1`|
|Fabric Loader|`0.17.2`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

