### PR TITLE
[Auto] Update to Minecraft 1.21.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
+loader_version=0.18.1
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,4 +17,4 @@ maven_group=co.secretonline.tinyflowers
 archives_base_name=tiny-flowers
 
 # Dependencies
-fabric_version=0.134.0+1.21.9
+fabric_version=0.138.3+1.21.10

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,9 +41,15 @@
   "icon": "assets/tiny-flowers/icon.png",
   "environment": "*",
   "entrypoints": {
-    "main": ["co.secretonline.tinyflowers.TinyFlowers"],
-    "client": ["co.secretonline.tinyflowers.TinyFlowersClient"],
-    "fabric-datagen": ["co.secretonline.tinyflowers.datagen.DataGenerator"]
+    "main": [
+      "co.secretonline.tinyflowers.TinyFlowers"
+    ],
+    "client": [
+      "co.secretonline.tinyflowers.TinyFlowersClient"
+    ],
+    "fabric-datagen": [
+      "co.secretonline.tinyflowers.datagen.DataGenerator"
+    ]
   },
   "mixins": [
     "tiny-flowers.mixins.json",
@@ -57,7 +63,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.17.2",
+    "fabricloader": ">=0.18.1",
     "minecraft": "~1.21.9"
   },
   "custom": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.10` (Compatible: `~1.21.9`)|
|Java|`21`|
|Yarn Mappings|`1.21.10+build.3`|
|Fabric API|`0.138.3+1.21.10`|
|Mod Menu|`16.0.0-rc.1`|
|Fabric Loader|`0.18.1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

