### PR TITLE
[Auto] Update to Minecraft 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ maven_group=co.secretonline.tinyflowers
 archives_base_name=tiny-flowers
 
 # Dependencies
-fabric_version=0.141.2+1.21.11
+fabric_version=0.141.3+1.21.11


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.11` (Compatible: `~1.21.11`)|
|Java|`21`|
|Fabric API|`0.141.3+1.21.11`|
|Mod Menu|`17.0.0-beta.2`|
|Fabric Loader|`0.18.4`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

