### PR TITLE
[Auto] Update to Minecraft 26.1.2

### DIFF
--- a/fabric/src/main/java/co/secretonline/tinyflowers/FabricTinyFlowersClient.java
+++ b/fabric/src/main/java/co/secretonline/tinyflowers/FabricTinyFlowersClient.java
@@ -1,16 +1,13 @@
 package co.secretonline.tinyflowers;
 
 import co.secretonline.tinyflowers.block.entity.ModBlockEntities;
-import co.secretonline.tinyflowers.block.ModBlocks;
 import co.secretonline.tinyflowers.renderer.blockentity.TinyGardenBlockEntityRenderer;
 import co.secretonline.tinyflowers.renderer.item.ModSelectItemModelProperties;
 import co.secretonline.tinyflowers.resources.FabricFlowerModelDataLoader;
 import co.secretonline.tinyflowers.resources.FabricFlowerModelLoadingPlugin;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendering.v1.ChunkSectionLayerMap;
 import net.fabricmc.fabric.impl.client.model.loading.ModelLoadingPluginManager;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.properties.select.SelectItemModelProperties;
 
 public class FabricTinyFlowersClient implements ClientModInitializer {
@@ -18,7 +15,6 @@ public class FabricTinyFlowersClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		SelectItemModelProperties.ID_MAPPER.put(ModSelectItemModelProperties.TINY_FLOWER_PROPERTY_ID, ModSelectItemModelProperties.TINY_FLOWER_PROPERTY);
 		BlockEntityRenderers.register(ModBlockEntities.TINY_GARDEN_BLOCK_ENTITY.get(), TinyGardenBlockEntityRenderer::new);
-		ChunkSectionLayerMap.putBlock(ModBlocks.TINY_GARDEN_BLOCK.get(), ChunkSectionLayer.CUTOUT);
 
 		ModelLoadingPluginManager.registerPlugin(new FabricFlowerModelDataLoader(), new FabricFlowerModelLoadingPlugin());
 	}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -41,19 +41,25 @@
   "icon": "assets/${mod_id}/icon.png",
   "environment": "*",
   "entrypoints": {
-    "main": ["co.secretonline.tinyflowers.FabricTinyFlowers"],
-    "client": ["co.secretonline.tinyflowers.FabricTinyFlowersClient"],
-    "fabric-datagen": ["co.secretonline.tinyflowers.datagen.FabricTinyFlowersDataGenerator"]
+    "main": [
+      "co.secretonline.tinyflowers.FabricTinyFlowers"
+    ],
+    "client": [
+      "co.secretonline.tinyflowers.FabricTinyFlowersClient"
+    ],
+    "fabric-datagen": [
+      "co.secretonline.tinyflowers.datagen.FabricTinyFlowersDataGenerator"
+    ]
   },
   "mixins": [
     "tiny_flowers.mixins.json"
   ],
   "depends": {
-    "java": ">=${java_version}",
+    "java": ">=25",
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=${fabric_loader_version}",
+    "fabricloader": ">=0.19.2",
     "minecraft": "~${minecraft_version}"
   },
   "custom": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ group=co.secretonline.tinyflowers
 java_version=25
 
 # Common
-minecraft_version=26.1-snapshot-6
+minecraft_version=26.1.2
 mod_name=Tiny Flowers
 mod_author=secret_online
 mod_id=tiny_flowers
@@ -20,11 +20,11 @@ minecraft_version_range=[21.6,)
 neo_form_version=26.1-snapshot-6-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.143.2+26.1
-fabric_loader_version=0.18.4
+fabric_version=0.146.1+26.1.2
+fabric_loader_version=0.19.2
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.0.0-alpha.10+snapshot-6
+neoforge_version=26.1.0.0-alpha.1+snapshot-1
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ group=co.secretonline.tinyflowers
 java_version=25
 
 # Common
-minecraft_version=26.1-snapshot-6
+minecraft_version=26.1.2
 mod_name=Tiny Flowers
 mod_author=secret_online
 mod_id=tiny_flowers
@@ -20,11 +20,11 @@ minecraft_version_range=[21.6,)
 neo_form_version=26.1-snapshot-6-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.143.2+26.1
-fabric_loader_version=0.18.4
+fabric_version=0.149.0+26.1.2
+fabric_loader_version=0.19.2
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.0.0-alpha.10+snapshot-6
+neoforge_version=26.1.0.0-alpha.1+snapshot-1
 neoforge_loader_version_range=[4,)
 
 # Gradle


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`26.1.2`|
|Java|`25`|
|Fabric Loader|`0.19.2`|
|Fabric API|`0.146.1+26.1.2`|
|NeoForge|`26.1.0.0-alpha.1+snapshot-1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

